### PR TITLE
Enhance API security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-rate-limit": "7.5.1",
         "form-data": "^4.0.4",
         "puppeteer": "^24.15.0",
         "puppeteer-extra": "^3.3.6",
@@ -3730,6 +3731,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/extract-zip": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "7.5.1",
     "form-data": "^4.0.4",
     "puppeteer": "^24.15.0",
     "puppeteer-extra": "^3.3.6",

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import rateLimit from 'express-rate-limit';
 
 import scanRoute from './routes/scan';
 import confirmRoute from './routes/confirm';
@@ -12,6 +13,12 @@ const app = express();
 
 app.use(cors());
 app.use(express.json({ limit: '15mb' }));
+
+const limiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+});
+app.use(limiter);
 
 app.use('/scan', scanRoute);
 app.use('/confirm', confirmRoute);

--- a/server/routes/confirm.ts
+++ b/server/routes/confirm.ts
@@ -1,12 +1,14 @@
 // server/routes/confirm.ts
 import express from 'express';
 import { supabase } from '../utils/supabaseClient';
+import { isValidCode, isValidName } from '../utils/validation';
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
   const { code, name = '', size = '' } = req.body;
-  if (!code) return res.status(400).json({ error: 'Missing code' });
+  if (!isValidCode(code)) return res.status(403).json({ error: 'Invalid code' });
+  if (name && !isValidName(name)) return res.status(403).json({ error: 'Invalid name' });
 
   const updates = {
     product_name: name,

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -2,12 +2,13 @@
 import express from 'express';
 import { supabase } from '../utils/supabaseClient';
 import { fetchBingLinks, fetchSdsByName, scrapeProductInfo } from '../utils/scraper';
+import { isValidCode } from '../utils/validation';
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
   const { code } = req.body;
-  if (!code) return res.status(400).json({ error: 'Missing barcode' });
+  if (!isValidCode(code)) return res.status(403).json({ error: 'Invalid barcode' });
   console.log('[SCAN] Searching for barcode:', code);
 
   // Check if already in DB

--- a/server/routes/sdsByName.ts
+++ b/server/routes/sdsByName.ts
@@ -1,12 +1,13 @@
 // server/routes/sdsByName.ts
 import express from 'express';
 import { fetchSdsByName } from '../utils/scraper';
+import { isValidName } from '../utils/validation';
 
 const router = express.Router();
 
 router.post('/', async (req, res) => {
   const { name } = req.body;
-  if (!name) return res.status(400).json({ error: 'Missing name' });
+  if (!isValidName(name)) return res.status(403).json({ error: 'Invalid name' });
 
   const sdsUrl = await fetchSdsByName(name);
   res.json({ sdsUrl });

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,8 @@
+export function isValidCode(code: any): code is string {
+  return typeof code === 'string' && /^[A-Za-z0-9_-]{1,64}$/.test(code);
+}
+
+export function isValidName(name: any): name is string {
+  if (typeof name !== 'string') return false;
+  return name.trim().length > 0 && name.length <= 100;
+}

--- a/tests/confirm.test.ts
+++ b/tests/confirm.test.ts
@@ -19,10 +19,10 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('POST /confirm returns 400 without code', async () => {
+test('POST /confirm returns 403 without code', async () => {
   const app = (await import('../server/app')).default;
   const res = await request(app).post('/confirm').send({});
-  expect(res.status).toBe(400);
+  expect(res.status).toBe(403);
 });
 
 test('POST /confirm updates product', async () => {

--- a/tests/scan.test.ts
+++ b/tests/scan.test.ts
@@ -22,10 +22,10 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test('POST /scan returns 400 without code', async () => {
+test('POST /scan returns 403 without code', async () => {
   const app = (await import('../server/app')).default;
   const res = await request(app).post('/scan').send({});
-  expect(res.status).toBe(400);
+  expect(res.status).toBe(403);
 });
 
 test('POST /scan returns existing product and updates SDS', async () => {

--- a/tests/sdsByName.test.ts
+++ b/tests/sdsByName.test.ts
@@ -12,7 +12,7 @@ afterEach(() => {
 test('POST /sds-by-name requires name', async () => {
   const app = (await import('../server/app')).default;
   const res = await request(app).post('/sds-by-name').send({});
-  expect(res.status).toBe(400);
+  expect(res.status).toBe(403);
 });
 
 test('POST /sds-by-name returns URL', async () => {


### PR DESCRIPTION
## Summary
- add express-rate-limit for basic rate limiting
- validate input with helper functions
- return 403 for invalid input values
- update tests to expect new 403 responses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f568523c832fa4e46bea20eabd76