### PR TITLE
Add health check endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ Returns a matching SDS PDF URL.
 ---
 
 ## 🧪 Health Check
-You can check PaddleOCR GPU status with:
+The backend exposes a simple health endpoint for uptime checks:
+```
+GET http://localhost:3000/health
+```
+The OCR microservice still provides a GPU status check at:
 ```
 GET http://localhost:5001/gpu-check
 ```

--- a/server/app.ts
+++ b/server/app.ts
@@ -6,6 +6,7 @@ import rateLimit from 'express-rate-limit';
 import scanRoute from './routes/scan';
 import confirmRoute from './routes/confirm';
 import sdsByNameRoute from './routes/sdsByName';
+import healthRoute from './routes/health';
 
 dotenv.config();
 
@@ -23,5 +24,6 @@ app.use(limiter);
 app.use('/scan', scanRoute);
 app.use('/confirm', confirmRoute);
 app.use('/sds-by-name', sdsByNameRoute);
+app.use('/health', healthRoute);
 
 export default app;

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,0 +1,9 @@
+import express from 'express';
+
+const router = express.Router();
+
+router.get('/', (_req, res) => {
+  res.json({ status: 'ok', uptime: process.uptime() });
+});
+
+export default router;

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -1,0 +1,12 @@
+import request from 'supertest';
+
+process.env.SB_URL = 'http://localhost';
+process.env.SB_SERVICE_KEY = 'key';
+
+test('GET /health returns status', async () => {
+  const app = (await import('../server/app')).default;
+  const res = await request(app).get('/health');
+  expect(res.status).toBe(200);
+  expect(res.body.status).toBe('ok');
+  expect(typeof res.body.uptime).toBe('number');
+});


### PR DESCRIPTION
## Summary
- add `/health` route for uptime checks
- wire new route into Express app
- document health check endpoint in README
- test `/health` route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889f8a5e480832fab0ad6968f88ea30