### PR TITLE
fix: unwrap Bing redirect URLs

### DIFF
--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -31,6 +31,21 @@ function normaliseUrl(u: string): string | null {
   if (!u) return null;
   let s = String(u).trim();
   try {
+    const parsed = new URL(s);
+    // Unwrap Bing redirect links: https://www.bing.com/ck/a?...&u=<encoded>
+    if (parsed.hostname.includes('bing.com') && parsed.searchParams.has('u')) {
+      let target = parsed.searchParams.get('u') || '';
+      try {
+        if (isProbablyA1Base64(target)) {
+          target = Buffer.from(target.slice(2), 'base64').toString('utf8');
+        } else {
+          target = decodeURIComponent(target);
+        }
+      } catch {}
+      s = target.trim();
+    }
+  } catch {}
+  try {
     if (isProbablyA1Base64(s)) {
       const decoded = Buffer.from(s.slice(2), 'base64').toString('utf8');
       if (decoded.startsWith('http://') || decoded.startsWith('https://')) s = decoded;


### PR DESCRIPTION
## Summary
- decode Bing click-through URLs in `normaliseUrl`

## Testing
- `npm test` *(fails: POST /confirm returns 403, POST /sds-by-name requires name, POST /scan returns existing product and updates SDS, GET /health returns status)*

------
https://chatgpt.com/codex/tasks/task_e_689a6a1261b4832fb599c103bdee3548