### PR TITLE
Simplify scraper logic

### DIFF
--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -78,16 +78,11 @@ async function fetchSdsByName(name: string): Promise<{ sdsUrl: string; topLinks:
     for (const href of topLinks) {
       const url = normaliseUrl(href);
       if (!url) continue;
-      const isPdf = url.toLowerCase().includes('.pdf');
-      const host = new URL(url).hostname;
-      const isJunk = host.includes('isocol.com.au');
-      logger.info({ href: url, isPdf, isJunk }, '[SCRAPER] Evaluating SDS link');
-      if (isPdf && !isJunk) {
-        return { sdsUrl: url, topLinks };
-      }
+      logger.info({ href: url }, '[SCRAPER] Evaluating link');
+      return { sdsUrl: url, topLinks };
     }
 
-    logger.info({ links }, '[SCRAPER] No matching SDS PDFs found');
+    logger.info({ links }, '[SCRAPER] No matching links found');
     return { sdsUrl: '', topLinks };
   } catch (err: any) {
     logger.warn({ err: String(err) }, '[SCRAPER] Puppeteer SDS search failed');

--- a/server/utils/scraper.ts
+++ b/server/utils/scraper.ts
@@ -88,7 +88,6 @@ export async function searchItemByBarcode(barcode: string): Promise<{ name: stri
   for (const query of queries) {
     const hits = await searchAu(query);
     for (const hit of hits.slice(0, 8)) {
-      if (!/\.au\b/i.test(hit.url) && /amazon|aliexpress|ebay/i.test(hit.url)) continue;
       try {
         const html = await fetchHtml(hit.url);
         const $ = cheerio.load(html);
@@ -102,7 +101,7 @@ export async function searchItemByBarcode(barcode: string): Promise<{ name: stri
         if (title) texts.push(title);
 
         const joined = texts.join(" • ");
-        const name = joined.replace(/\s*[-|–]\s*(Buy.*|Bunnings.*|Officeworks.*|Woolworths.*)$/i, "").trim();
+        const name = joined.trim();
         const size = joined.match(/\b(\d+(?:\.\d+)?)\s?(mL|L|g|kg)\b/i)?.[0];
 
         if (name) {
@@ -164,7 +163,7 @@ export async function scrapeProductInfo(url: string): Promise<{ name?: string; c
   if (title) texts.push(title);
 
   const joined = texts.join(" • ");
-  const name = joined.replace(/\s*[-|–]\s*(Buy.*|Bunnings.*|Officeworks.*|Woolworths.*)$/i, "").trim();
+  const name = joined.trim();
   const size = joined.match(/\b(\d+(?:\.\d+)?)\s?(mL|L|g|kg)\b/i)?.[0];
 
   return { name, contents_size_weight: size, url };


### PR DESCRIPTION
## Summary
- Remove special-case URL and PDF checks when selecting SDS links
- Drop marketplace filtering and name cleanup in scraper helpers

## Testing
- `npm test` *(fails: POST /sds-by-name requires name, POST /sds-by-name returns URL, POST /confirm returns 403 without code, POST /confirm updates product, GET /health returns status, POST /scan returns 403 without code, POST /scan returns existing product and updates SDS)*

------
https://chatgpt.com/codex/tasks/task_e_689b07426c28832f8d13fd05a918877d