### PR TITLE
feat: prevent duplicate register entries

### DIFF
--- a/tests/confirm.test.ts
+++ b/tests/confirm.test.ts
@@ -5,14 +5,23 @@ process.env.SB_SERVICE_KEY = 'key';
 
 jest.mock('../server/utils/supabaseClient', () => ({ supabase: { from: jest.fn() } }));
 
-function setupSupabase(response: {data: any; error: any}) {
+function setupSupabase(existing: any, upsertResult?: any) {
   const { supabase } = require('../server/utils/supabaseClient');
-  const chain: any = {};
-  chain.update = jest.fn(() => chain);
-  chain.eq = jest.fn(() => chain);
-  chain.select = jest.fn(() => chain);
-  chain.maybeSingle = jest.fn(() => Promise.resolve(response));
-  (supabase.from as jest.Mock).mockReturnValue(chain);
+
+  const selectChain: any = {};
+  selectChain.select = jest.fn(() => selectChain);
+  selectChain.eq = jest.fn(() => selectChain);
+  selectChain.maybeSingle = jest.fn(() => Promise.resolve({ data: existing, error: null }));
+
+  (supabase.from as jest.Mock).mockReturnValueOnce(selectChain);
+
+  if (upsertResult) {
+    const upsertChain: any = {};
+    upsertChain.upsert = jest.fn(() => upsertChain);
+    upsertChain.select = jest.fn(() => upsertChain);
+    upsertChain.maybeSingle = jest.fn(() => Promise.resolve({ data: upsertResult, error: null }));
+    (supabase.from as jest.Mock).mockReturnValueOnce(upsertChain);
+  }
 }
 
 afterEach(() => {
@@ -25,8 +34,11 @@ test('POST /confirm returns 403 without code', async () => {
   expect(res.status).toBe(403);
 });
 
-test('POST /confirm updates product', async () => {
-  setupSupabase({ data: { barcode: '123', name: 'New', contents_size_weight: '10ml' }, error: null });
+test('POST /confirm upserts product when details change', async () => {
+  setupSupabase(
+    { barcode: '123', name: 'Old', contents_size_weight: '5ml' },
+    { barcode: '123', name: 'New', contents_size_weight: '10ml' }
+  );
   const app = (await import('../server/app')).default;
 
   const res = await request(app).post('/confirm').send({ code: '123', name: 'New', size: '10ml' });
@@ -34,4 +46,14 @@ test('POST /confirm updates product', async () => {
   expect(res.status).toBe(200);
   expect(res.body.success).toBe(true);
   expect(res.body.product.name).toBe('New');
+});
+
+test('POST /confirm returns 409 for duplicate product', async () => {
+  setupSupabase({ barcode: '123', name: 'New', contents_size_weight: '10ml' });
+  const app = (await import('../server/app')).default;
+
+  const res = await request(app).post('/confirm').send({ code: '123', name: 'New', size: '10ml' });
+
+  expect(res.status).toBe(409);
+  expect(res.body.error).toBe('Product already registered');
 });


### PR DESCRIPTION
## Summary
- avoid duplicate products by returning conflict when /confirm receives identical payload
- cover duplicate product behavior with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c4ba96340832f90ae9170e805d35e