### PR TITLE
Persist SDS URL after manual confirmation

### DIFF
--- a/tests/confirm.test.ts
+++ b/tests/confirm.test.ts
@@ -4,8 +4,9 @@ process.env.SB_URL = 'http://localhost';
 process.env.SB_SERVICE_KEY = 'key';
 
 jest.mock('../server/utils/supabaseClient', () => ({ supabase: { from: jest.fn() } }));
+jest.mock('../server/utils/scraper', () => ({ fetchSdsByName: jest.fn() }));
 
-function setupSupabase(existing: any, upsertResult?: any) {
+function setupSupabase(existing: any, upsertResult?: any, updateResult?: any) {
   const { supabase } = require('../server/utils/supabaseClient');
 
   const selectChain: any = {};
@@ -21,6 +22,15 @@ function setupSupabase(existing: any, upsertResult?: any) {
     upsertChain.select = jest.fn(() => upsertChain);
     upsertChain.maybeSingle = jest.fn(() => Promise.resolve({ data: upsertResult, error: null }));
     (supabase.from as jest.Mock).mockReturnValueOnce(upsertChain);
+  }
+
+  if (updateResult) {
+    const updateChain: any = {};
+    updateChain.update = jest.fn(() => updateChain);
+    updateChain.eq = jest.fn(() => updateChain);
+    updateChain.select = jest.fn(() => updateChain);
+    updateChain.maybeSingle = jest.fn(() => Promise.resolve({ data: updateResult, error: null }));
+    (supabase.from as jest.Mock).mockReturnValueOnce(updateChain);
   }
 }
 
@@ -39,6 +49,8 @@ test('POST /confirm upserts product when details change', async () => {
     { barcode: '123', name: 'Old', contents_size_weight: '5ml' },
     { barcode: '123', name: 'New', contents_size_weight: '10ml' }
   );
+  const { fetchSdsByName } = require('../server/utils/scraper');
+  (fetchSdsByName as jest.Mock).mockResolvedValue({ sdsUrl: '', topLinks: [] });
   const app = (await import('../server/app')).default;
 
   const res = await request(app).post('/confirm').send({ code: '123', name: 'New', size: '10ml' });
@@ -50,10 +62,28 @@ test('POST /confirm upserts product when details change', async () => {
 
 test('POST /confirm returns 409 for duplicate product', async () => {
   setupSupabase({ barcode: '123', name: 'New', contents_size_weight: '10ml' });
+  const { fetchSdsByName } = require('../server/utils/scraper');
+  (fetchSdsByName as jest.Mock).mockResolvedValue({ sdsUrl: '', topLinks: [] });
   const app = (await import('../server/app')).default;
 
   const res = await request(app).post('/confirm').send({ code: '123', name: 'New', size: '10ml' });
 
   expect(res.status).toBe(409);
   expect(res.body.error).toBe('Product already registered');
+});
+
+test('POST /confirm stores SDS URL when lookup succeeds', async () => {
+  setupSupabase(
+    { barcode: '123', name: 'Old', contents_size_weight: '5ml' },
+    { barcode: '123', name: 'New', contents_size_weight: '10ml', sds_url: null },
+    { barcode: '123', name: 'New', contents_size_weight: '10ml', sds_url: 'http://sds.com/test.pdf' }
+  );
+  const { fetchSdsByName } = require('../server/utils/scraper');
+  (fetchSdsByName as jest.Mock).mockResolvedValue({ sdsUrl: 'http://sds.com/test.pdf', topLinks: [] });
+  const app = (await import('../server/app')).default;
+
+  const res = await request(app).post('/confirm').send({ code: '123', name: 'New', size: '10ml' });
+
+  expect(res.status).toBe(200);
+  expect(res.body.product.sds_url).toBe('http://sds.com/test.pdf');
 });


### PR DESCRIPTION
## Summary
- fetch SDS PDF after manual confirm and store URL in database
- test confirm route updates record with SDS link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c7ba54084832faff6da805314e888