### PR TITLE
Add Section 16 date fallback for issue date detection

### DIFF
--- a/ocr_service/parse_sds.py
+++ b/ocr_service/parse_sds.py
@@ -138,6 +138,10 @@ PATTERNS.update({
         r"(\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4}|\d{1,2}\s+[A-Za-z]{3,9}\s+\d{4})",
         re.I,
     ),
+    "generic_date": re.compile(
+        r"(\d{4}-\d{2}-\d{2}|\d{1,2}/\d{1,2}/\d{2,4}|\d{1,2}\s+[A-Za-z]{3,9}\s+\d{4})",
+        re.I,
+    ),
 })
 
 
@@ -183,6 +187,20 @@ def _resolve_issue_date(sect16: str, full_text: str) -> Optional[str]:
                 return iso
         except Exception:
             # If parsing the ISO string fails unexpectedly, still return it
+            return iso
+
+    # Fallback: any unlabelled date present in Section 16
+    raw = _find_first(PATTERNS["generic_date"], sect16)
+    if raw:
+        try:
+            iso = _normalise_date(raw)
+        except Exception:
+            iso = raw
+        try:
+            dt = datetime.fromisoformat(iso).date()
+            if dt <= date.today() + timedelta(days=60):
+                return iso
+        except Exception:
             return iso
 
     return None

--- a/ocr_service/test_issue_date_fallback.py
+++ b/ocr_service/test_issue_date_fallback.py
@@ -1,0 +1,7 @@
+import parse_sds
+
+
+def test_fallback_date_from_section_16():
+    sect16 = "Date of issue / Date of\n13/04/2023 revision."
+    result = parse_sds._resolve_issue_date(sect16, "")
+    assert result == "2023-04-13"


### PR DESCRIPTION
## Summary
- broaden date recognition with a generic date regex
- fall back to any date found in Section 16 when labeled dates are missing
- add unit test covering Section 16 date fallback

## Testing
- `pytest ocr_service/test_issue_date_fallback.py -q`
- `pytest ocr_service -q` *(fails: pytest: reading from stdin while output is captured)*
- `pytest ocr_service -k 'not test_file' -q`
- `npm test` *(fails: 9 failed, 9 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a059fe360c832fbfaedab88c8d57a2