### PR TITLE
Fix product use parsing for SDS

### DIFF
--- a/ocr_service/parse_sds.py
+++ b/ocr_service/parse_sds.py
@@ -53,8 +53,8 @@ PATTERNS: Dict[str, re.Pattern] = {
     "product_identifier_alt": re.compile(r"^\s*IDENTIFICATION\s*OF\s*THE\s*SUBSTANCE.*?\n(.*?)\n", re.I | re.S),
     "vendor_block_13": re.compile(r"1\.3\s*(?:Details|Supplier|Manufacturer|Company).*?(?:\n\n|\Z)", re.I | re.S),
     "product_use": re.compile(
-        r"(?:Recommended\s+use|Uses?\s+of\s+the\s+substance(?:/mixture)?|Product\s+use)\s*(?:[:\-]\s*)?\n?\s*([^\n]+)",
-        re.I,
+        r"(?:Recommended\s+use|Uses?\s+of\s+the\s+substance(?:/mixture)?|Product\s+use|^Use)\s*(?:[:\-]\s*)?\n?\s*([^\n]+)",
+        re.I | re.M,
     ),
     # Dangerous goods / transport
     "dg_none": re.compile(r"(?:not\s+(?:subject|regulated)|not\s+classified\s+as\s+dangerous\s+goods)", re.I),

--- a/ocr_service/result.json
+++ b/ocr_service/result.json
@@ -2,8 +2,8 @@
   "product_id": 174,
   "vendor": "Nicepak Products Pty Ltd",
   "product_name": "ISOCOL Rubbing Alcohol",
-  "product_use": null,
-  "issue_date": "2023-03-08",
+  "product_use": "Antibacterial rub preparation for topical human use.",
+  "issue_date": "2022-03-29",
   "hazardous_substance": true,
   "hazardous_confidence": 0.9,
   "hazard_statements": [
@@ -25,21 +25,21 @@
     "P210 Keep away from heat/sparks/open \nflames/hot surfaces",
     "P233 Keep container tightly closed \nP240 Ground/bond container and receiving \nequipment",
     "P241 Use explosion-proof \nelectrical/ventilating/lighting/intrinsically \nsafe equipment",
-    "P242 Use only non-\n\n PRODUCT NAME: ISOCOL Rubbing Alcohol \n \n \nPage 2 of 6 \n \n \n \nSAFETY DATA SHEET \nsparking tools",
+    "P242 Use only non-\nsparking tools",
     "P243 Take precautionary measures \nagainst static discharge",
     "P261 Avoid \nbreathing mist/vapours/spray",
     "P264 Wash exposed skin thoroughly after \nhandling P271 Use only outdoors or in a \nwell-ventilated area",
     "P280 Wear protective gloves/protective \nclothing/eye protection/face protection \nResponse Statement(s) \nP303+P361+P353 IF ON SKIN (or hair): Remove/Take off immediately all contaminated \nclothing",
     "P304 +P340 IF INHALED: remove victim to fresh air and keep at rest in a \nposition comfortable for breathing \nP305+P351+P338 If in eyes: Rinse cautiously with water for several minutes",
     "P312 Call a POISON CENTER/doctor/physician if you feel unwell P337+P313 \nIf eye irritation persists: Get medical advice/attention \nP370+P378 In case of fire: Use dry chemical powder, alcohol resistant foam, \ncarbon dioxide (CO2) for extinction \nStorage Statement(s) \nP403+P233 Store in a well-ventilated place",
-    "P235 Keep \ncool \nDisposal Statement(s) \nP501 Dispose of contents/container to comply with local, state and federal \nregulations \nOther Hazards \nMarine Pollutant: No \n\n PRODUCT NAME: ISOCOL Rubbing Alcohol \n \n \nPage 3 of 6 \n \n \n \nSAFETY DATA SHEET"
+    "P235 Keep \ncool \nDisposal Statement(s) \nP501 Dispose of contents/container to comply with local, state and federal \nregulations \nOther Hazards \nMarine Pollutant: No \n\n PRODUCT NAME: ISOCOL Rubbing Alcohol \nPage 3 of 6 \nSAFETY DATA SHEET"
   ],
   "cas_numbers": [
     "67-63-0"
   ],
   "proper_shipping_name": "DG Class",
-  "section_1_excerpt": "IDENTIFICATION OF THE MATERIAL AND SUPPLIER Product Name ISOCOL Rubbing Alcohol Product Codes 1NPK001 – 345mL Bottle 1NPK002 – 75mL Spray 1NPK003 – 450mL Spray Manufacturer Nicepak Products Address 120 Woodlands Drive Braeside Vic 3195 Australia Emergency Telephone Number +61 3 8586 0500 Australia – 13 11 26 (Poisons Information Centre) Facsimile Number +61 3 8586 0505 Manufacturer’s Formulation Name ISOCOL Rubbing Alcohol Formulation Item Number: 2NPK001 Use Antibacterial rub preparation for topical human use.",
-  "section_2_excerpt": "HAZARDS IDENFICATION Description Contains Isopropyl Alcohol 64% which is hazardous according to Worksafe Australia. GHS label elements Signal Words Danger Hazard Classification Highly flammable liquid and vapour - category 2 Eye irritation - category 2A Specific target organ toxicity (single exposure) – category 3 Hazard Statement(s) H225 Highly flammable liquid and vapour. H319 Causes serious eye irritation. H336 May cause drowsiness or dizziness. Precautionary Statement(s) P101 If medical advice is needed, have product container or label at hand. P102 Keep out of reach of children. P103 Read label before use. P210 Keep away from heat/sparks/open flames/hot surfaces. - No smoking. P233 Keep container tightly closed P240 Ground/bond container and receiving equipment. P241 Use explosion-proof electrical/ventilating/lighting/intrinsically safe equipment. P242 Use only non- PRODUCT NAME: IS",
+  "section_1_excerpt": "IDENTIFICATION OF THE MATERIAL AND SUPPLIER Product Name ISOCOL Rubbing Alcohol Product Codes 1NPK001 – 345mL Bottle 1NPK002 – 75mL Spray Manufacturer Nicepak Products Address 120 Woodlands Drive Braeside Vic 3195 Australia Emergency Telephone Number +61 3 8586 0500 Australia – 13 11 26 (Poisons Information Centre) Facsimile Number +61 3 8586 0505 Manufacturer’s Formulation Name ISOCOL Rubbing Alcohol Formulation Item Number: 2NPK001 Use Antibacterial rub preparation for topical human use.",
+  "section_2_excerpt": "HAZARDS IDENFICATION Description Contains Isopropyl Alcohol 64% which is hazardous according to Worksafe Australia. GHS label elements Signal Words Danger Hazard Classification Highly flammable liquid and vapour - category 2 Eye irritation - category 2A Specific target organ toxicity (single exposure) – category 3 Hazard Statement(s) H225 Highly flammable liquid and vapour. H319 Causes serious eye irritation. H336 May cause drowsiness or dizziness. Precautionary Statement(s) P101 If medical advice is needed, have product container or label at hand. P102 Keep out of reach of children. P103 Read label before use. P210 Keep away from heat/sparks/open flames/hot surfaces. - No smoking. P233 Keep container tightly closed P240 Ground/bond container and receiving equipment. P241 Use explosion-proof electrical/ventilating/lighting/intrinsically safe equipment. P242 Use only non- sparking tools. ",
   "section_14_excerpt": "TRANSPORT INFORMATION Regulation UN Number Proper Shipping Name DG Class Packing Group Label Additional Information ADG UN1987 ALCOHOLS, N.O.S. [Isopropyl Alcohol]",
-  "section_16_excerpt": "OTHER INFORMATION SDS Prepared by Nicepak Products Pty Ltd Date Prepared 08/03/2023 Revision Date 08/03/2028 Version Number"
+  "section_16_excerpt": "OTHER INFORMATION SDS Prepared by Nicepak Products Pty Ltd Date Prepared 29/03/2022 Revision Date 29/03/2027 Version Number"
 }

--- a/ocr_service/test_product_use.py
+++ b/ocr_service/test_product_use.py
@@ -4,3 +4,8 @@ from parse_sds import _extract_product_use
 def test_extract_product_use_multiline():
     sect = "Product use:\n Antiseptic and disinfectant"
     assert _extract_product_use(sect) == "Antiseptic and disinfectant"
+
+
+def test_extract_product_use_simple_use_label():
+    sect = "Formulation Item Number: 2NPK001\nUse\nAntibacterial rub preparation for topical human use."
+    assert _extract_product_use(sect) == "Antibacterial rub preparation for topical human use."


### PR DESCRIPTION
## Summary
- expand product use regex to handle standalone 'Use' labels
- cover standalone 'Use' label in unit tests
- refresh sample result to include product_use

## Testing
- `pytest -q` *(fails: pytest: reading from stdin while output is captured!  Consider using `-s`.)*
- `pytest -q test_product_use.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0711ccba0832fb851a226dc97d5d6